### PR TITLE
Provide pointer to parent schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters-settings:
     check-type-assertions: true
     check-blank: true
   gocyclo:
-    min-complexity: 30
+    min-complexity: 35
   dupl:
     threshold: 100
   misspell:

--- a/context.go
+++ b/context.go
@@ -36,6 +36,7 @@ type InterceptTypeFunc func(reflect.Value, *Schema) (bool, error)
 // InterceptPropertyFunc can intercept field reflection to control or modify schema.
 //
 // Return ErrSkipProperty to avoid adding this property to parent Schema.Properties.
+// Pointer to parent Schema is available in propertySchema.Parent.
 type InterceptPropertyFunc func(name string, field reflect.StructField, propertySchema *Schema) error
 
 // InterceptType adds hook to customize schema.

--- a/entities.go
+++ b/entities.go
@@ -62,6 +62,7 @@ type Schema struct {
 	Not                  *SchemaOrBool                               `json:"not,omitempty"` // Core schema meta-schema.
 	ExtraProperties      map[string]interface{}                      `json:"-"`             // All unmatched properties.
 	ReflectType          reflect.Type                                `json:"-"`
+	Parent               *Schema                                     `json:"-"`
 }
 
 // WithID sets ID value.

--- a/example_test.go
+++ b/example_test.go
@@ -269,6 +269,8 @@ func ExampleInterceptProperty() {
 			// You can alter reflected schema by updating propertySchema.
 			case "id":
 				propertySchema.WithDescription("This is ID.")
+				// You can access schema that holds the property.
+				propertySchema.Parent.WithDescription("Schema with ID.")
 
 			// Or you can entirely remove property from parent schema with a sentinel error.
 			case "skipped":
@@ -290,6 +292,7 @@ func ExampleInterceptProperty() {
 	fmt.Println(string(j))
 	// Output:
 	// {
+	//   "description":"Schema with ID.",
 	//   "properties":{
 	//     "id":{"description":"This is ID.","default":200,"minimum":123,"type":"integer"},
 	//     "name":{"minLength":10,"type":"string"}


### PR DESCRIPTION
One use case is to control parent schema when intercepting property schema.