### PR TITLE
Use unnamed fields to configure parent schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters-settings:
     check-type-assertions: true
     check-blank: true
   gocyclo:
-    min-complexity: 35
+    min-complexity: 40
   dupl:
     threshold: 100
   misspell:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ This library provides Go structures to marshal/unmarshal and reflect [JSON Schem
 
 ```go
 type MyStruct struct {
-    Amount float64 `json:"amount" minimum:"10.5" example:"20.6" required:"true"`
-    Abc    string  `json:"abc" pattern:"[abc]"`
+    Amount float64  `json:"amount" minimum:"10.5" example:"20.6" required:"true"`
+    Abc    string   `json:"abc" pattern:"[abc]"`
+    _      struct{} `additionalProperties:"false"`                   // Tags of unnamed field are applied to parent schema.
+    _      struct{} `title:"My Struct" description:"Holds my data."` // Multiple unnamed fields can be used.
 }
 
 reflector := jsonschema.Reflector{}
@@ -37,9 +39,12 @@ fmt.Println(string(j))
 
 // Output:
 // {
+//  "title": "My Struct",
+//  "description": "Holds my data.",
 //  "required": [
 //   "amount"
 //  ],
+//  "additionalProperties": false,
 //  "properties": {
 //   "abc": {
 //    "pattern": "[abc]",

--- a/example_test.go
+++ b/example_test.go
@@ -179,8 +179,10 @@ func ExampleReflector_Reflect() {
 
 func ExampleReflector_Reflect_simple() {
 	type MyStruct struct {
-		Amount float64 `json:"amount" minimum:"10.5" example:"20.6" required:"true"`
-		Abc    string  `json:"abc" pattern:"[abc]"`
+		Amount float64  `json:"amount" minimum:"10.5" example:"20.6" required:"true"`
+		Abc    string   `json:"abc" pattern:"[abc]"`
+		_      struct{} `additionalProperties:"false"`                   // Tags of unnamed field are applied to parent schema.
+		_      struct{} `title:"My Struct" description:"Holds my data."` // Multiple unnamed fields can be used.
 	}
 
 	reflector := jsonschema.Reflector{}
@@ -199,9 +201,12 @@ func ExampleReflector_Reflect_simple() {
 
 	// Output:
 	// {
+	//  "title": "My Struct",
+	//  "description": "Holds my data.",
 	//  "required": [
 	//   "amount"
 	//  ],
+	//  "additionalProperties": false,
 	//  "properties": {
 	//   "abc": {
 	//    "pattern": "[abc]",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bool64/dev v0.2.10
 	github.com/stretchr/testify v1.7.1
 	github.com/swaggest/assertjson v1.6.8
-	github.com/swaggest/refl v1.0.1
+	github.com/swaggest/refl v1.0.2
 	github.com/yudai/gojsondiff v1.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/bool64/dev v0.1.25/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.1.41/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
-github.com/bool64/dev v0.1.42/go.mod h1:cTHiTDNc8EewrQPy3p1obNilpMpdmlUesDkFTF2zRWU=
 github.com/bool64/dev v0.2.10 h1:ypAGBazcwyIy2JvIJio8V3kdqO7AgIAYvcckW54qxr4=
 github.com/bool64/dev v0.2.10/go.mod h1:/csLrm+4oDSsKJRIVS0mrywAonLnYKFG8RvGT7Jh9b8=
 github.com/bool64/shared v0.1.3 h1:gj7XZPYa1flQsCg3q9AIju+W2A1jaexK0fdFu2XtaG0=
@@ -57,8 +56,8 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/swaggest/assertjson v1.6.8 h1:1O/9UI5M+2OJI7BeEWKGj0wTvpRXZt5FkOJ4nRkY4rA=
 github.com/swaggest/assertjson v1.6.8/go.mod h1:Euf0upn9Vlaf1/llYHTs+Kx5K3vVbpMbsZhth7zlN7M=
-github.com/swaggest/refl v1.0.1 h1:YQHb7Ic6EMpdUpxQmTWmf/O4IWN6iIErxJNWA7LwyyM=
-github.com/swaggest/refl v1.0.1/go.mod h1:dnx+n9YaI0o+FH+OR2tJZWLABBVIPs9qc4VY9UdrhLE=
+github.com/swaggest/refl v1.0.2 h1:VmP8smuDS1EzUPn31++TzMi13CAaVJdlWpIxzj0up88=
+github.com/swaggest/refl v1.0.2/go.mod h1:DoiPoBJPYHU6Z9fIA6zXQ9uI6VRL6M8BFX5YFT+ym9g=
 github.com/yosuke-furukawa/json5 v0.1.2-0.20201207051438-cf7bb3f354ff/go.mod h1:sw49aWDqNdRJ6DYUtIQiaA3xyj2IL9tjeNYmX2ixwcU=
 github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1015,14 +1015,13 @@ func TestReflector_Reflect_parentTags(t *testing.T) {
 	}`), s)
 
 	// Failure scenarios.
-	s, err = r.Reflect(struct {
+	_, err = r.Reflect(struct {
 		_ string `additionalProperties:"abc"`
 	}{})
 	assert.EqualError(t, err, "failed to parse bool value abc in tag additionalProperties: strconv.ParseBool: parsing \"abc\": invalid syntax")
 
-	s, err = r.Reflect(struct {
+	_, err = r.Reflect(struct {
 		_ string `minProperties:"abc"`
 	}{})
 	assert.EqualError(t, err, "failed to parse int value abc in tag minProperties: strconv.ParseInt: parsing \"abc\": invalid syntax")
-
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1013,4 +1013,16 @@ func TestReflector_Reflect_parentTags(t *testing.T) {
 	  "title":"Test","description":"This is a test.","additionalProperties":false,
 	  "properties":{"foo":{"type":"string"}},"type":"object"
 	}`), s)
+
+	// Failure scenarios.
+	s, err = r.Reflect(struct {
+		_ string `additionalProperties:"abc"`
+	}{})
+	assert.EqualError(t, err, "failed to parse bool value abc in tag additionalProperties: strconv.ParseBool: parsing \"abc\": invalid syntax")
+
+	s, err = r.Reflect(struct {
+		_ string `minProperties:"abc"`
+	}{})
+	assert.EqualError(t, err, "failed to parse int value abc in tag minProperties: strconv.ParseInt: parsing \"abc\": invalid syntax")
+
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -993,3 +993,24 @@ func TestReflector_Reflect_processWithoutTags_false(t *testing.T) {
 	  "type":"object"
 	}`), s)
 }
+
+func TestReflector_Reflect_parentTags(t *testing.T) {
+	type Test struct {
+		Foo string   `json:"foo"`
+		_   struct{} `title:"Test"` // Tags of unnamed field are applied to parent schema.
+
+		// There can be more than one field to set up parent schema.
+		// Types of such fields are not relevant, only tags matter.
+		_ string `additionalProperties:"false" description:"This is a test."`
+	}
+
+	r := jsonschema.Reflector{}
+
+	s, err := r.Reflect(Test{})
+	assert.NoError(t, err)
+
+	assertjson.EqualMarshal(t, []byte(`{
+	  "title":"Test","description":"This is a test.","additionalProperties":false,
+	  "properties":{"foo":{"type":"string"}},"type":"object"
+	}`), s)
+}


### PR DESCRIPTION
```go
	type Test struct {
		Foo string   `json:"foo"`
		_   struct{} `title:"Test"` // Tags of unnamed field are applied to parent schema.

		// There can be more than one field to set up parent schema.
		// Types of such fields are not relevant, only tags matter.
		_ string `additionalProperties:"false" description:"This is a test."`
	}
```
Such type would be reflected to 
```json
{
	  "title":"Test","description":"This is a test.","additionalProperties":false,
	  "properties":{"foo":{"type":"string"}},"type":"object"
}
```