### PR TITLE
Add `examples` field tag, allow array item example, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ These tags can be used:
 * [`title`](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.6.1), string
 * [`description`](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.6.1), string
 * [`default`](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.6.2), can be scalar or JSON value
+* [`example`](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-examples), a scalar value that matches type of parent property, for an array it is applied to items
+* [`examples`](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-examples), a JSON array value
 * [`const`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.3), can be scalar or JSON value
 * [`pattern`](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.5.2.3), string
 * [`format`](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.7), string

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1275,3 +1275,27 @@ func TestReflector_Reflect_skipNonConstraints(t *testing.T) {
 	  }
 	}`), s)
 }
+
+func TestReflector_Reflect_examples(t *testing.T) {
+	type WantExample struct {
+		A string   `json:"a" example:"example of a"`
+		B []string `json:"b" example:"example of b"`
+		C int      `json:"c" examples:"[\"foo\", 2, 3]" example:"123"`
+	}
+
+	reflector := jsonschema.Reflector{}
+	schema, err := reflector.Reflect(WantExample{})
+	require.NoError(t, err)
+
+	assertjson.EqualMarshal(t, []byte(`{
+	  "properties":{
+		"a":{"examples":["example of a"],"type":"string"},
+		"b":{
+		  "items":{"examples":["example of b"],"type":"string"},
+		  "type":["array","null"]
+		},
+		"c":{"examples":[123,"foo",2,3],"type":"integer"}
+	  },
+	  "type":"object"
+	}`), schema)
+}


### PR DESCRIPTION
Fixes #49.

Also adds support for `examples` field tag with raw json array value.