### PR TITLE
Fix nullable pointer to struct

### DIFF
--- a/context.go
+++ b/context.go
@@ -190,13 +190,3 @@ type ReflectContext struct {
 	typeCycles     map[refl.TypeString]bool
 	rootDefName    string
 }
-
-func (rc *ReflectContext) getDefinition(ref string) Schema {
-	for ts, r := range rc.definitionRefs {
-		if r.Path+r.Name == ref {
-			return rc.definitions[ts]
-		}
-	}
-
-	return Schema{}
-}

--- a/example_test.go
+++ b/example_test.go
@@ -153,7 +153,12 @@ func ExampleReflector_Reflect() {
 	//   },
 	//   "nullableWhatever": {},
 	//   "parent": {
-	//    "$ref": "#"
+	//    "type": "null",
+	//    "anyOf": [
+	//     {
+	//      "$ref": "#"
+	//     }
+	//    ]
 	//   },
 	//   "recursiveArray": {
 	//    "items": {

--- a/example_test.go
+++ b/example_test.go
@@ -154,7 +154,7 @@ func ExampleReflector_Reflect() {
 	//   "nullableWhatever": {},
 	//   "parent": {
 	//    "type": "null",
-	//    "anyOf": [
+	//    "allOf": [
 	//     {
 	//      "$ref": "#"
 	//     }

--- a/reflect.go
+++ b/reflect.go
@@ -935,10 +935,6 @@ func checkInlineValue(propertySchema *Schema, field reflect.StructField, tag str
 }
 
 func checkNullability(propertySchema *Schema, ft reflect.Type) {
-	if propertySchema.HasType(Object) && len(propertySchema.Properties) == 0 && propertySchema.Ref == nil {
-		propertySchema.AddType(Null)
-	}
-
 	if ft.Kind() == reflect.Ptr && propertySchema.Ref != nil {
 		refSchema := *propertySchema
 		propertySchema.Ref = nil

--- a/reflect.go
+++ b/reflect.go
@@ -938,7 +938,7 @@ func checkNullability(propertySchema *Schema, ft reflect.Type) {
 	if ft.Kind() == reflect.Ptr && propertySchema.Ref != nil {
 		refSchema := *propertySchema
 		propertySchema.Ref = nil
-		propertySchema.AnyOf = []SchemaOrBool{
+		propertySchema.AllOf = []SchemaOrBool{
 			refSchema.ToSchemaOrBool(),
 		}
 		propertySchema.Type = nil

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/swaggest/assertjson"
-
 	"github.com/swaggest/jsonschema-go"
 )
 
@@ -427,15 +426,17 @@ func TestReflector_Reflect_pointer_envelop(t *testing.T) {
 	type NamedMap map[string]St
 
 	type Cont struct {
-		PtrOmitempty      *St           `json:"ptrOmitempty,omitempty"`
-		Ptr               *St           `json:"ptr"`
-		Val               St            `json:"val"`
-		SliceOmitempty    []St          `json:"sliceOmitempty,omitempty" minItems:"3"`
-		Slice             []St          `json:"slice" minItems:"2"`
-		MapOmitempty      map[string]St `json:"mapOmitempty,omitempty" minProperties:"3"`
-		Map               map[string]St `json:"map" minProperties:"2"`
-		NamedMapOmitempty NamedMap      `json:"namedMapOmitempty,omitempty" minProperties:"1"`
-		NamedMap          NamedMap      `json:"namedMap" minProperties:"5"`
+		PtrOmitempty      *St            `json:"ptrOmitempty,omitempty"`
+		Ptr               *St            `json:"ptr"`
+		Val               St             `json:"val"`
+		SliceOmitempty    []St           `json:"sliceOmitempty,omitempty" minItems:"3"`
+		Slice             []St           `json:"slice" minItems:"2"`
+		PointerMap        *map[string]St `json:"pointerMap" minProperties:"2"`
+		MapOmitempty      map[string]St  `json:"mapOmitempty,omitempty" minProperties:"3"`
+		Map               map[string]St  `json:"map" minProperties:"2"`
+		NamedMapOmitempty NamedMap       `json:"namedMapOmitempty,omitempty" minProperties:"1"`
+		NamedMap          NamedMap       `json:"namedMap" minProperties:"5"`
+		PointerNamedMap   *NamedMap      `json:"pointerNamedMap" minProperties:"5"`
 	}
 
 	s, err := (&jsonschema.Reflector{}).Reflect(Cont{}, func(rc *jsonschema.ReflectContext) {
@@ -469,10 +470,7 @@ func TestReflector_Reflect_pointer_envelop(t *testing.T) {
         	            	   "additionalProperties": {
         	            	    "$ref": "#/definitions/JsonschemaGoTestSt"
         	            	   },
-        	            	   "type": [
-        	            	    "object",
-        	            	    "null"
-        	            	   ]
+        	            	   "type": "object"
         	            	  },
         	            	  "mapOmitempty": {
         	            	   "minProperties": 3,
@@ -481,43 +479,56 @@ func TestReflector_Reflect_pointer_envelop(t *testing.T) {
         	            	   },
         	            	   "type": "object"
         	            	  },
+                              "pointerMap": {
+                               "additionalProperties": {
+                                "$ref": "#/definitions/JsonschemaGoTestSt"
+                               },
+                               "minProperties": 2,
+                               "type": [
+                                 "null",
+                                 "object"
+                               ]
+                              },
         	            	  "namedMap": {
         	            	   "minProperties": 5,
-        	            	   "anyOf": [
-        	            	    {
-        	            	     "type": "null"
-        	            	    },
-        	            	    {
-        	            	     "$ref": "#/definitions/JsonschemaGoTestNamedMap"
-        	            	    }
-        	            	   ]
+							   "$ref": "#/definitions/JsonschemaGoTestNamedMap"
         	            	  },
         	            	  "namedMapOmitempty": {
         	            	   "$ref": "#/definitions/JsonschemaGoTestNamedMap",
         	            	   "minProperties": 1
         	            	  },
+                              "pointerNamedMap": {
+                               "anyOf": [
+                                {
+                                 "$ref": "#/definitions/JsonschemaGoTestNamedMap"
+                                }
+                               ],
+                               "minProperties": 5,
+                               "type": "null"
+                              },
         	            	  "ptr": {
         	            	   "anyOf": [
         	            	    {
-        	            	     "type": "null"
-        	            	    },
-        	            	    {
         	            	     "$ref": "#/definitions/JsonschemaGoTestSt"
         	            	    }
-        	            	   ]
+        	            	   ],
+							   "type": "null"
         	            	  },
         	            	  "ptrOmitempty": {
-        	            	   "$ref": "#/definitions/JsonschemaGoTestSt"
+                               "anyOf": [
+                                {
+                                 "$ref": "#/definitions/JsonschemaGoTestSt",
+                                 "type": "object"
+                                }
+                               ],
+                               "type": "null"
         	            	  },
         	            	  "slice": {
         	            	   "items": {
         	            	    "$ref": "#/definitions/JsonschemaGoTestSt"
         	            	   },
         	            	   "minItems": 2,
-        	            	   "type": [
-        	            	    "array",
-        	            	    "null"
-        	            	   ]
+        	            	   "type": "array"
         	            	  },
         	            	  "sliceOmitempty": {
         	            	   "items": {
@@ -542,15 +553,17 @@ func TestReflector_Reflect_pointer(t *testing.T) {
 	type NamedMap map[string]St
 
 	type Cont struct {
-		PtrOmitempty      *St           `json:"ptrOmitempty,omitempty"`
-		Ptr               *St           `json:"ptr"`
-		Val               St            `json:"val"`
-		SliceOmitempty    []St          `json:"sliceOmitempty,omitempty" minItems:"3"`
-		Slice             []St          `json:"slice" minItems:"2"`
-		MapOmitempty      map[string]St `json:"mapOmitempty,omitempty" minProperties:"3"`
-		Map               map[string]St `json:"map" minProperties:"2"`
-		NamedMapOmitempty NamedMap      `json:"namedMapOmitempty,omitempty" minProperties:"1"`
-		NamedMap          NamedMap      `json:"namedMap" minProperties:"5"`
+		PtrOmitempty      *St            `json:"ptrOmitempty,omitempty"`
+		Ptr               *St            `json:"ptr"`
+		Val               St             `json:"val"`
+		SliceOmitempty    []St           `json:"sliceOmitempty,omitempty" minItems:"3"`
+		Slice             []St           `json:"slice" minItems:"2"`
+		MapOmitempty      map[string]St  `json:"mapOmitempty,omitempty" minProperties:"3"`
+		Map               map[string]St  `json:"map" minProperties:"2"`
+		PointerMap        *map[string]St `json:"pointerMap" minProperties:"2"`
+		NamedMapOmitempty NamedMap       `json:"namedMapOmitempty,omitempty" minProperties:"1"`
+		NamedMap          NamedMap       `json:"namedMap" minProperties:"5"`
+		PointerNamedMap   *NamedMap      `json:"pointerNamedMap" minProperties:"5"`
 	}
 
 	s, err := (&jsonschema.Reflector{}).Reflect(Cont{})
@@ -582,10 +595,7 @@ func TestReflector_Reflect_pointer(t *testing.T) {
         	            	   "additionalProperties": {
         	            	    "$ref": "#/definitions/JsonschemaGoTestSt"
         	            	   },
-        	            	   "type": [
-        	            	    "object",
-        	            	    "null"
-        	            	   ]
+        	            	   "type": "object"
         	            	  },
         	            	  "mapOmitempty": {
         	            	   "minProperties": 3,
@@ -594,6 +604,16 @@ func TestReflector_Reflect_pointer(t *testing.T) {
         	            	   },
         	            	   "type": "object"
         	            	  },
+                              "pointerMap": {
+                               "additionalProperties": {
+                                "$ref": "#/definitions/JsonschemaGoTestSt"
+                               },
+                               "minProperties": 2,
+                               "type": [
+                                "null",
+                                "object"
+                               ]
+                              },
         	            	  "namedMap": {
         	            	   "$ref": "#/definitions/JsonschemaGoTestNamedMap",
         	            	   "minProperties": 5
@@ -602,21 +622,38 @@ func TestReflector_Reflect_pointer(t *testing.T) {
         	            	   "$ref": "#/definitions/JsonschemaGoTestNamedMap",
         	            	   "minProperties": 1
         	            	  },
+                              "pointerNamedMap": {
+                               "anyOf": [
+                                {
+                                 "$ref": "#/definitions/JsonschemaGoTestNamedMap"
+                                }
+                               ],
+                               "minProperties": 5,
+                               "type": "null"
+                              },
         	            	  "ptr": {
-        	            	   "$ref": "#/definitions/JsonschemaGoTestSt"
+                               "anyOf": [
+                                {
+ 								 "$ref": "#/definitions/JsonschemaGoTestSt"
+                                }
+                               ],
+                               "type": "null"
         	            	  },
         	            	  "ptrOmitempty": {
-        	            	   "$ref": "#/definitions/JsonschemaGoTestSt"
+                               "anyOf": [
+                                {
+                                 "$ref": "#/definitions/JsonschemaGoTestSt",
+                                 "type": "object"
+                                }
+                               ],
+                               "type": "null"
         	            	  },
         	            	  "slice": {
         	            	   "items": {
         	            	    "$ref": "#/definitions/JsonschemaGoTestSt"
         	            	   },
         	            	   "minItems": 2,
-        	            	   "type": [
-        	            	    "array",
-        	            	    "null"
-        	            	   ]
+        	            	   "type": "array"
         	            	  },
         	            	  "sliceOmitempty": {
         	            	   "items": {
@@ -850,7 +887,7 @@ func TestReflector_Reflect_MapOfOptionals(t *testing.T) {
 	  "properties":{
 		"map":{
 		  "additionalProperties":{"type":["null","number"]},
-		  "type":["object","null"]
+		  "type":"object"
 		},
 		"slice":{"items":{"type":["null","number"]},"type":"array"}
 	  },

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/swaggest/assertjson"
+
 	"github.com/swaggest/jsonschema-go"
 )
 
@@ -127,7 +128,14 @@ func TestReflector_Reflect(t *testing.T) {
 		"deathDate":{"type":["null","string"],"format":"date"},
 		"deletedAt":{"type":["null","string"],"format":"date-time"},
 		"enumed":{"$ref":"#/definitions/JsonschemaGoTestEnumed"},
-		"enumedPtr":{"$ref":"#/definitions/JsonschemaGoTestEnumed"},
+		"enumedPtr":{
+		 "anyOf": [
+          {
+		   "$ref": "#/definitions/JsonschemaGoTestEnumed"
+   		  }
+		 ],
+		 "type": "null"
+		},
 		"firstName":{"type":"string"},"height":{"type":"integer"},
 		"lastName":{"type":"string"},"meta":{},
 		"role":{
@@ -140,7 +148,15 @@ func TestReflector_Reflect(t *testing.T) {
 	"JsonschemaGoTestRole":{"type":"string"}
   },
   "properties":{
-	"chiefOfMorale":{"$ref":"#/definitions/JsonschemaGoTestPerson"},
+	"chiefOfMorale":{
+	 "anyOf": [
+	  {
+	   "$ref": "#/definitions/JsonschemaGoTestPerson",
+	   "type": "object"
+	  }
+	 ],
+	 "type": "null"
+	},
 	"employees":{"items":{"$ref":"#/definitions/JsonschemaGoTestPerson"},"type":"array"}
   },
   "type":"object"
@@ -240,7 +256,13 @@ func TestReflector_Reflect_collectDefinitions(t *testing.T) {
  "title": "Organization",
  "properties": {
   "chiefOfMorale": {
-   "$ref": "#/definitions/JsonschemaGoTestPerson"
+   "anyOf": [
+    {
+     "$ref": "#/definitions/JsonschemaGoTestPerson",
+     "type": "object"
+    }
+   ],
+   "type": "null"
   },
   "employees": {
    "items": {
@@ -250,8 +272,7 @@ func TestReflector_Reflect_collectDefinitions(t *testing.T) {
   }
  },
  "type": "object"
-}
-`), j, string(j))
+}`), j, string(j))
 
 	assertjson.EqualMarshal(t, []byte(`
 {
@@ -265,7 +286,14 @@ func TestReflector_Reflect_collectDefinitions(t *testing.T) {
 	  "deathDate":{"type":["null","string"],"format":"date"},
 	  "deletedAt":{"type":["null","string"],"format":"date-time"},
 	  "enumed":{"$ref":"#/definitions/JsonschemaGoTestEnumed"},
-	  "enumedPtr":{"$ref":"#/definitions/JsonschemaGoTestEnumed"},
+	  "enumedPtr":{
+	   "anyOf": [
+	    {
+	     "$ref": "#/definitions/JsonschemaGoTestEnumed"
+	    }
+	   ],
+	   "type": "null"
+      },
 	  "firstName":{"type":"string"},"height":{"type":"integer"},
 	  "lastName":{"type":"string"},"meta":{},
 	  "role":{
@@ -292,8 +320,19 @@ func TestReflector_Reflect_recursiveStruct(t *testing.T) {
 	j, err := json.Marshal(s)
 	require.NoError(t, err)
 
-	assertjson.Equal(t, []byte(`{"properties":{"parent":{"$ref":"#"},"siblings":{"items":{"$ref":"#"},"type":"array"},
-		"val":{"type":"string"}},"type":"object"}`), j, string(j))
+	assertjson.Equal(t, []byte(`{
+		"properties": {
+		 "parent":{
+		  "anyOf": [
+		   {
+		    "$ref": "#"
+		   }
+		  ],
+		  "type": "null"
+		 },
+   		 "siblings":{"items":{"$ref":"#"},"type":"array"},
+		 "val":{"type":"string"}},"type":"object"
+	}`), j, string(j))
 }
 
 func TestReflector_Reflect_mapping(t *testing.T) {
@@ -526,10 +565,7 @@ func TestReflector_Reflect_pointer(t *testing.T) {
         	            	   "additionalProperties": {
         	            	    "$ref": "#/definitions/JsonschemaGoTestSt"
         	            	   },
-        	            	   "type": [
-        	            	    "object",
-        	            	    "null"
-        	            	   ]
+        	            	   "type": "object"
         	            	  },
         	            	  "JsonschemaGoTestSt": {
         	            	   "properties": {
@@ -537,10 +573,7 @@ func TestReflector_Reflect_pointer(t *testing.T) {
         	            	     "type": "integer"
         	            	    }
         	            	   },
-        	            	   "type": [
-        	            	    "object",
-        	            	    "null"
-        	            	   ]
+        	            	   "type": "object"
         	            	  }
         	            	 },
         	            	 "properties": {
@@ -819,7 +852,7 @@ func TestReflector_Reflect_MapOfOptionals(t *testing.T) {
 		  "additionalProperties":{"type":["null","number"]},
 		  "type":["object","null"]
 		},
-		"slice":{"items":{"type":["null","number"]},"type":["array","null"]}
+		"slice":{"items":{"type":["null","number"]},"type":"array"}
 	  },
 	  "type":"object"
 	}`), s)
@@ -917,7 +950,14 @@ func TestReflector_Reflect_sub_schema(t *testing.T) {
 			"deathDate":{"type":["null","string"],"format":"date"},
 			"deletedAt":{"type":["null","string"],"format":"date-time"},
 			"enumed":{"$ref":"#/definitions/Enumed"},
-			"enumedPtr":{"$ref":"#/definitions/Enumed"},
+			"enumedPtr":{
+			 "anyOf": [
+			  {
+			   "$ref": "#/definitions/Enumed"
+			  }
+			 ],
+			 "type": "null"
+			},
 			"firstName":{"type":"string"},"height":{"type":"integer"},
 			"lastName":{"type":"string"},"meta":{},
 			"role":{"$ref":"#/definitions/Role","description":"The role of person."}
@@ -1313,7 +1353,7 @@ func TestReflector_Reflect_examples(t *testing.T) {
 		"a":{"examples":["example of a"],"type":"string"},
 		"b":{
 		  "items":{"examples":["example of b"],"type":"string"},
-		  "type":["array","null"]
+		  "type":"array"
 		},
 		"c":{"examples":[123,"foo",2,3],"type":"integer"}
 	  },
@@ -1334,7 +1374,7 @@ func TestReflector_Reflect_namedSlice(t *testing.T) {
 
 	assertjson.EqualMarshal(t, []byte(`{
 	  "definitions":{
-		"JsonschemaGoTestPanicType":{"items":{"type":"string"},"type":["array","null"]}
+		"JsonschemaGoTestPanicType":{"items":{"type":"string"},"type":"array"}
 	  },
 	  "properties":{"ip_policy":{"$ref":"#/definitions/JsonschemaGoTestPanicType"}},
 	  "type":"object"

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -128,7 +128,7 @@ func TestReflector_Reflect(t *testing.T) {
 		"deletedAt":{"type":["null","string"],"format":"date-time"},
 		"enumed":{"$ref":"#/definitions/JsonschemaGoTestEnumed"},
 		"enumedPtr":{
-		 "anyOf": [
+		 "allOf": [
           {
 		   "$ref": "#/definitions/JsonschemaGoTestEnumed"
    		  }
@@ -148,7 +148,7 @@ func TestReflector_Reflect(t *testing.T) {
   },
   "properties":{
 	"chiefOfMorale":{
-	 "anyOf": [
+	 "allOf": [
 	  {
 	   "$ref": "#/definitions/JsonschemaGoTestPerson",
 	   "type": "object"
@@ -255,7 +255,7 @@ func TestReflector_Reflect_collectDefinitions(t *testing.T) {
  "title": "Organization",
  "properties": {
   "chiefOfMorale": {
-   "anyOf": [
+   "allOf": [
     {
      "$ref": "#/definitions/JsonschemaGoTestPerson",
      "type": "object"
@@ -286,7 +286,7 @@ func TestReflector_Reflect_collectDefinitions(t *testing.T) {
 	  "deletedAt":{"type":["null","string"],"format":"date-time"},
 	  "enumed":{"$ref":"#/definitions/JsonschemaGoTestEnumed"},
 	  "enumedPtr":{
-	   "anyOf": [
+	   "allOf": [
 	    {
 	     "$ref": "#/definitions/JsonschemaGoTestEnumed"
 	    }
@@ -322,7 +322,7 @@ func TestReflector_Reflect_recursiveStruct(t *testing.T) {
 	assertjson.Equal(t, []byte(`{
 		"properties": {
 		 "parent":{
-		  "anyOf": [
+		  "allOf": [
 		   {
 		    "$ref": "#"
 		   }
@@ -498,7 +498,7 @@ func TestReflector_Reflect_pointer_envelop(t *testing.T) {
         	            	   "minProperties": 1
         	            	  },
                               "pointerNamedMap": {
-                               "anyOf": [
+                               "allOf": [
                                 {
                                  "$ref": "#/definitions/JsonschemaGoTestNamedMap"
                                 }
@@ -507,7 +507,7 @@ func TestReflector_Reflect_pointer_envelop(t *testing.T) {
                                "type": "null"
                               },
         	            	  "ptr": {
-        	            	   "anyOf": [
+        	            	   "allOf": [
         	            	    {
         	            	     "$ref": "#/definitions/JsonschemaGoTestSt"
         	            	    }
@@ -515,7 +515,7 @@ func TestReflector_Reflect_pointer_envelop(t *testing.T) {
 							   "type": "null"
         	            	  },
         	            	  "ptrOmitempty": {
-                               "anyOf": [
+                               "allOf": [
                                 {
                                  "$ref": "#/definitions/JsonschemaGoTestSt",
                                  "type": "object"
@@ -623,7 +623,7 @@ func TestReflector_Reflect_pointer(t *testing.T) {
         	            	   "minProperties": 1
         	            	  },
                               "pointerNamedMap": {
-                               "anyOf": [
+                               "allOf": [
                                 {
                                  "$ref": "#/definitions/JsonschemaGoTestNamedMap"
                                 }
@@ -632,7 +632,7 @@ func TestReflector_Reflect_pointer(t *testing.T) {
                                "type": "null"
                               },
         	            	  "ptr": {
-                               "anyOf": [
+                               "allOf": [
                                 {
  								 "$ref": "#/definitions/JsonschemaGoTestSt"
                                 }
@@ -640,7 +640,7 @@ func TestReflector_Reflect_pointer(t *testing.T) {
                                "type": "null"
         	            	  },
         	            	  "ptrOmitempty": {
-                               "anyOf": [
+                               "allOf": [
                                 {
                                  "$ref": "#/definitions/JsonschemaGoTestSt",
                                  "type": "object"
@@ -988,7 +988,7 @@ func TestReflector_Reflect_sub_schema(t *testing.T) {
 			"deletedAt":{"type":["null","string"],"format":"date-time"},
 			"enumed":{"$ref":"#/definitions/Enumed"},
 			"enumedPtr":{
-			 "anyOf": [
+			 "allOf": [
 			  {
 			   "$ref": "#/definitions/Enumed"
 			  }


### PR DESCRIPTION
**Problem:** nullable struct or map
Field which is a **pointer** to struct or map must be nullable
**Omitempty** option must not lead to ignoring checking nullable

**Examples:** 

**1. Field Ptr - pointer to struct St**

```
type St struct {
  A int `json:"a"`
}

type Cont struct {
  Ptr               *St            `json:"ptr"`
}
```

Before fix:
```
"ptr": {
  "$ref": "#/definitions/JsonschemaGoTestSt"
}
```

After fix: 
```
ptr": {
  "allOf": [
    {
      "$ref": "#/definitions/JsonschemaGoTestSt"
    }
  ],
  "type": "null"
}
```

**2. Field PtrOmitempty - pointer to struct - omitempty option**

```
type St struct {
  A int `json:"a"`
}

type Cont struct {
  PtrOmitempty *St `json:"ptrOmitempty,omitempty"`
}
```

Before fix:
```
"ptrOmitempty": {
  "$ref": "#/definitions/JsonschemaGoTestSt"
}
```

After fix: 
```
"ptrOmitempty": {
  "allOf": [
    {
      "$ref": "#/definitions/JsonschemaGoTestSt"
    }
  ],
  "type": "null"
}
```


**3. Field PointerNamedMap - pointer to map**

```
type St struct {
  A int `json:"a"`
}

type NamedMap map[string]St

type Cont struct {
  PointerNamedMap   *NamedMap      `json:"pointerNamedMap" minProperties:"5"`
}
```

Before fix:
```
"pointerNamedMap": {
  "$ref": "#/definitions/JsonschemaGoTestNamedMap",
  "minProperties": 5
}
```

After fix: 
```
"pointerNamedMap": {
  "allOf": [
    {
      "$ref": "#/definitions/JsonschemaGoTestNamedMap"
    }
  ],
  "minProperties": 5,
  "type": "null"
}
```

**4. Type NamedMap - map**

```
type St struct {
  A int `json:"a"`
}

type NamedMap map[string]St
```

Before fix:
```
"JsonschemaGoTestNamedMap": {
  "additionalProperties": {
    "$ref": "#/definitions/JsonschemaGoTestSt"
  },
  "type": [
    "object",
    "null"
   ]
}
```

After fix: 
```
"JsonschemaGoTestNamedMap": {
  "additionalProperties": {
    "$ref": "#/definitions/JsonschemaGoTestSt"
  },
  "type": "object"
}
```

