### PR TITLE
Add InterceptNullability hook to ReflectContext, tweak and describe nullability rules

### DIFF
--- a/context.go
+++ b/context.go
@@ -40,6 +40,20 @@ type InterceptTypeFunc func(reflect.Value, *Schema) (bool, error)
 // Pointer to parent Schema is available in propertySchema.Parent.
 type InterceptPropertyFunc func(name string, field reflect.StructField, propertySchema *Schema) error
 
+// InterceptNullability defines InterceptNullabilityFunc parameters.
+type InterceptNullability struct {
+	OrigSchema Schema
+	Schema     *Schema
+	Type       reflect.Type
+	OmitEmpty  bool
+	NullAdded  bool
+	RefDef     *Schema
+}
+
+// InterceptNullabilityFunc can intercept schema reflection to control or modify nullability state.
+// It is called after default nullability rules are applied.
+type InterceptNullabilityFunc func(params InterceptNullability)
+
 // InterceptType adds hook to customize schema.
 func InterceptType(f InterceptTypeFunc) func(*ReflectContext) {
 	return func(rc *ReflectContext) {
@@ -175,8 +189,9 @@ type ReflectContext struct {
 	// InterceptType is called before and after type processing.
 	// So it may be called twice for the same type, first time with empty Schema and
 	// second time with fully processed schema.
-	InterceptType     InterceptTypeFunc
-	InterceptProperty InterceptPropertyFunc
+	InterceptType        InterceptTypeFunc
+	InterceptProperty    InterceptPropertyFunc
+	InterceptNullability InterceptNullabilityFunc
 
 	// SkipNonConstraints disables parsing of `default` and `example` field tags.
 	SkipNonConstraints bool
@@ -185,18 +200,18 @@ type ReflectContext struct {
 	SkipUnsupportedProperties bool
 
 	Path           []string
-	definitions    map[refl.TypeString]Schema // list of all definition objects
+	definitions    map[refl.TypeString]*Schema // list of all definition objects
 	definitionRefs map[refl.TypeString]Ref
 	typeCycles     map[refl.TypeString]bool
 	rootDefName    string
 }
 
-func (rc *ReflectContext) getDefinition(ref string) Schema {
+func (rc *ReflectContext) getDefinition(ref string) *Schema {
 	for ts, r := range rc.definitionRefs {
 		if r.Path+r.Name == ref {
 			return rc.definitions[ts]
 		}
 	}
 
-	return Schema{}
+	return &Schema{}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -191,7 +191,7 @@ func ExampleReflector_Reflect() {
 		log.Fatal(err)
 	}
 
-	j, err := json.MarshalIndent(schema, "", " ")
+	j, err := assertjson.MarshalIndentCompact(schema, "", "  ", 80)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -200,85 +200,34 @@ func ExampleReflector_Reflect() {
 
 	// Output:
 	// {
-	//  "title": "Sample Response",
-	//  "description": "This is a sample response.",
-	//  "definitions": {
-	//   "NamedAnything": {},
-	//   "UUID": {
-	//    "examples": [
-	//     "248df4b7-aa70-47b8-a036-33ac447e668d"
-	//    ],
-	//    "type": "string",
-	//    "format": "uuid"
-	//   }
-	//  },
-	//  "properties": {
-	//   "arrayOfAnything": {
-	//    "items": {},
-	//    "type": "array"
-	//   },
-	//   "arrayOfNamedAnything": {
-	//    "items": {
-	//     "$ref": "#/definitions/NamedAnything"
-	//    },
-	//    "type": "array"
-	//   },
-	//   "field1": {
-	//    "type": "integer"
-	//   },
-	//   "field2": {
-	//    "type": "string"
-	//   },
-	//   "info": {
-	//    "required": [
-	//     "foo"
-	//    ],
-	//    "properties": {
-	//     "bar": {
-	//      "description": "This is Bar.",
-	//      "type": "number"
-	//     },
-	//     "foo": {
-	//      "default": "baz",
-	//      "pattern": "\\d+",
-	//      "type": "string"
+	//   "title":"Sample Response","description":"This is a sample response.",
+	//   "definitions":{
+	//     "NamedAnything":{},
+	//     "UUID":{
+	//       "examples":["248df4b7-aa70-47b8-a036-33ac447e668d"],"type":"string",
+	//       "format":"uuid"
 	//     }
-	//    },
-	//    "type": "object"
 	//   },
-	//   "map": {
-	//    "additionalProperties": {
-	//     "type": "integer"
-	//    },
-	//    "type": "object"
+	//   "properties":{
+	//     "arrayOfAnything":{"items":{},"type":"array"},
+	//     "arrayOfNamedAnything":{"items":{"$ref":"#/definitions/NamedAnything"},"type":"array"},
+	//     "field1":{"type":"integer"},"field2":{"type":"string"},
+	//     "info":{
+	//       "required":["foo"],
+	//       "properties":{
+	//         "bar":{"description":"This is Bar.","type":"number"},
+	//         "foo":{"default":"baz","pattern":"\\d+","type":"string"}
+	//       },
+	//       "type":"object"
+	//     },
+	//     "map":{"additionalProperties":{"type":"integer"},"type":"object"},
+	//     "mapOfAnything":{"additionalProperties":{},"type":"object"},
+	//     "nullableWhatever":{},"parent":{"$ref":"#"},
+	//     "recursiveArray":{"items":{"$ref":"#"},"type":"array"},
+	//     "recursiveStructArray":{"items":{"$ref":"#"},"type":"array"},
+	//     "uuid":{"$ref":"#/definitions/UUID"},"whatever":{}
 	//   },
-	//   "mapOfAnything": {
-	//    "additionalProperties": {},
-	//    "type": "object"
-	//   },
-	//   "nullableWhatever": {},
-	//   "parent": {
-	//    "$ref": "#"
-	//   },
-	//   "recursiveArray": {
-	//    "items": {
-	//     "$ref": "#"
-	//    },
-	//    "type": "array"
-	//   },
-	//   "recursiveStructArray": {
-	//    "items": {
-	//     "$ref": "#"
-	//    },
-	//    "type": "array"
-	//   },
-	//   "uuid": {
-	//    "$ref": "#/definitions/UUID"
-	//   },
-	//   "whatever": {}
-	//  },
-	//  "type": "object",
-	//  "x-foo": "bar"
+	//   "type":"object","x-foo":"bar"
 	// }
 }
 

--- a/reflect.go
+++ b/reflect.go
@@ -214,6 +214,7 @@ func checkSchemaSetup(v reflect.Value, s *Schema) (bool, error) {
 //	CollectDefinitions
 //	DefinitionsPrefix
 //	PropertyNameTag
+//	InterceptNullability
 //	InterceptType
 //	InterceptProperty
 //	InlineRefs
@@ -966,7 +967,7 @@ func checkInlineValue(propertySchema *Schema, field reflect.StructField, tag str
 //   - Object without properties, it is a map, and it accepts `null` as a value.
 //   - Pointer type.
 func checkNullability(propertySchema *Schema, rc *ReflectContext, ft reflect.Type, omitEmpty bool) {
-	in := InterceptNullability{
+	in := InterceptNullabilityParams{
 		OrigSchema: *propertySchema,
 		Schema:     propertySchema,
 		Type:       ft,


### PR DESCRIPTION
#60 and #59 suggest changes of behavior as fixes, however I'm not convinced those changes are good for general (default) case.

This PR enables nullability customizations via user-defined `jsonschema.InterceptNullability` hook, e.g.

```go
	s, err := r.Reflect(Org{}, jsonschema.InterceptNullability(func(params jsonschema.InterceptNullabilityParams) {
		if params.Type.Kind() == reflect.Ptr {
			params.Schema.AddType(jsonschema.Null)
		}
	}))
```

Such a solution hopefully can address the need for behavior that isn't default.
