### PR TITLE
Reduce impact of Text(Un)Marshaler on schema processing

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -401,6 +401,11 @@ func (r *Reflector) reflect(i interface{}, rc *ReflectContext, keepType bool, pa
 		return schema, nil
 	}
 
+	if (t.Implements(typeOfTextUnmarshaler) || reflect.PtrTo(t).Implements(typeOfTextUnmarshaler)) &&
+		(t.Implements(typeOfTextMarshaler) || reflect.PtrTo(t).Implements(typeOfTextMarshaler)) {
+		schema.AddType(String)
+	}
+
 	if rc.InterceptType != nil {
 		if ret, err := rc.InterceptType(v, &schema); err != nil || ret {
 			return schema, err
@@ -562,13 +567,6 @@ func (r *Reflector) isWellKnownType(t reflect.Type, schema *Schema) bool {
 	if t == typeOfDate {
 		schema.AddType(String)
 		schema.WithFormat("date")
-
-		return true
-	}
-
-	if (t.Implements(typeOfTextUnmarshaler) || reflect.PtrTo(t).Implements(typeOfTextUnmarshaler)) &&
-		(t.Implements(typeOfTextMarshaler) || reflect.PtrTo(t).Implements(typeOfTextMarshaler)) {
-		schema.AddType(String)
 
 		return true
 	}


### PR DESCRIPTION
Fixes #64.

Now implementing a pair of TextMarshaler/TextUnmarshaler would add `string` type to schema, but would allow further processing and configuration (it would stop at `{"type":"string"}` before).