### PR TITLE
fix bug: generic types schema name

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -350,8 +351,8 @@ func (r *Reflector) reflect(i interface{}, rc *ReflectContext, keepType bool, pa
 		if err != nil {
 			return
 		}
-
-		schema = r.reflectDefer(defName, typeString, rc, schema, keepType)
+		m := regexp.MustCompile(`\W`)
+		schema = r.reflectDefer(m.ReplaceAllString(defName, "_"), typeString, rc, schema, keepType)
 	}()
 
 	if t == nil || t == typeOfEmptyInterface {


### PR DESCRIPTION
```go
package controllers
// Declare input port type.
type helloInput struct {
	Locale string `query:"locale" default:"en-US" pattern:"^[a-z]{2}-[A-Z]{2}$" enum:"ru-RU,en-US"`
	Name   string `path:"name" minLength:"3"` // Field tags define parameter location and JSON schema constraints.

	// Field tags of unnamed fields are applied to parent schema.
	// they are optional and can be used to disallow unknown parameters.
	// For non-body params, name tag must be provided explicitly.
	// E.g. here no unknown `query` and `cookie` parameters allowed,
	// unknown `header` params are ok.
	_ struct{} `query:"_" cookie:"_" additionalProperties:"false"`
}

// Declare output port type.
type helloOutput struct {
	Now     time.Time `header:"X-Now" json:"-"`
	Message string    `json:"message"`
}

type ApiRespone[T any] struct {
	Data *T `json:"data"`
}

func Hello() usecase.Interactor {
	messages := map[string]string{
		"en-US": "Hello, %s!",
		"ru-RU": "Привет, %s!",
	}

	// Create use case interactor with references to input/output types and interaction function.
	u := usecase.NewInteractor(func(ctx context.Context, input helloInput, output *ApiRespone[helloOutput]) error {
		msg, available := messages[input.Locale]
		if !available {
			return status.Wrap(errors.New("unknown locale"), status.InvalidArgument)
		}

		output.Data = &helloOutput{
			Message: fmt.Sprintf(msg, input.Name),
			Now:     time.Now(),
		}
		// output.Now = time.Now()

		return nil
	})

	// Describe use case interactor.
	u.SetTitle("Greeter")
	u.SetDescription("Greeter greets you.")

	u.SetExpectedErrors(status.InvalidArgument)
	return u
}
```
```go
package main

func main() {
	s := web.DefaultService()

	// Init API documentation schema.
	s.OpenAPI.Info.Title = "Basic Example"
	s.OpenAPI.Info.WithDescription("This app showcases a trivial REST API.")
	s.OpenAPI.Info.Version = "v1.2.3"

	// Setup middlewares.
	s.Wrap(
		gzip.Middleware, // Response compression with support for direct gzip pass through.
	)

	// Add use case handler to router.
	s.Get("/hello/{name}", controllers.Hello())

	// Swagger UI endpoint at /docs.
	s.Docs("/docs", swgui.New)

	// Start server.
	log.Println("http://localhost:8011/docs")
	if err := http.ListenAndServe(":8011", s); err != nil {
		log.Fatal(err)
	}
}


```

![](https://user-images.githubusercontent.com/1042568/224240196-1e9e7334-fd12-4bf9-9fe2-1e06e6accf61.png)

