### PR TITLE
Add deprecated and writeOnly as part of schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ These tags can be used:
 * [`example`](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-examples), a scalar value that matches type of parent property, for an array it is applied to items
 * [`examples`](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-examples), a JSON array value
 * [`const`](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.3), can be scalar or JSON value
+* [`deprecated`](https://json-schema.org/draft/2020-12/json-schema-validation#name-deprecated), boolean
+* [`readOnly`](https://json-schema.org/draft/2020-12/json-schema-validation#name-deprecated), boolean
+* [`writeOnly`](https://json-schema.org/draft/2020-12/json-schema-validation#name-deprecated), boolean
 * [`pattern`](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.5.2.3), string
 * [`format`](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.7), string
 * [`multipleOf`](https://json-schema.org/draft-04/json-schema-validation.html#rfc.section.5.1.1), float > 0

--- a/entities.go
+++ b/entities.go
@@ -23,6 +23,8 @@ type Schema struct {
 	Description          *string                                     `json:"description,omitempty"`
 	Default              *interface{}                                `json:"default,omitempty"`
 	ReadOnly             *bool                                       `json:"readOnly,omitempty"`
+	WriteOnly             *bool                                       `json:"writeOnly,omitempty"`
+	Deprecated             *bool                                       `json:"deprecated,omitempty"`
 	Examples             []interface{}                               `json:"examples,omitempty"`
 	MultipleOf           *float64                                    `json:"multipleOf,omitempty"`
 	Maximum              *float64                                    `json:"maximum,omitempty"`
@@ -110,6 +112,18 @@ func (s *Schema) WithDefault(val interface{}) *Schema {
 // WithReadOnly sets ReadOnly value.
 func (s *Schema) WithReadOnly(val bool) *Schema {
 	s.ReadOnly = &val
+	return s
+}
+
+// WithWriteOnly sets WriteOnly value.
+func (s *Schema) WithWriteOnly(val bool) *Schema {
+	s.WriteOnly = &val
+	return s
+}
+
+// WithDeprecated sets Deprecated value.
+func (s *Schema) WithDeprecated(val bool) *Schema {
+	s.Deprecated = &val
 	return s
 }
 

--- a/entities_test.go
+++ b/entities_test.go
@@ -79,3 +79,29 @@ func TestType_MarshalJSON_roundtrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(marshaled, &v))
 	assertjson.Equal(t, jsonValue, marshaled)
 }
+
+func TestSchemaWithWriteOnly_MarshalJSON_roundtrip(t *testing.T) {
+	var (
+		jsonValue = []byte(`{"$id":"someid","title":"title","description":"description","writeOnly":true}`)
+		v Schema
+	)
+
+	require.NoError(t, json.Unmarshal(jsonValue, &v))
+	marshaled, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(marshaled, &v))
+	assertjson.Equal(t, jsonValue, marshaled)
+}
+
+func TestSchemaWithDeprecated_MarshalJSON_roundtrip(t *testing.T) {
+	var (
+		jsonValue = []byte(`{"$id":"someid","title":"title","description":"description","deprecated":true}`)
+		v Schema
+	)
+
+	require.NoError(t, json.Unmarshal(jsonValue, &v))
+	marshaled, err := json.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(marshaled, &v))
+	assertjson.Equal(t, jsonValue, marshaled)
+}

--- a/reflect.go
+++ b/reflect.go
@@ -1161,13 +1161,6 @@ func (r *Reflector) walkProperties(v reflect.Value, parent *Schema, rc *ReflectC
 			return err
 		}
 
-		deprecated := false
-		if err := refl.ReadBoolTag(field.Tag, "deprecated", &deprecated); err != nil {
-			return err
-		} else if deprecated {
-			propertySchema.WithExtraPropertiesItem("deprecated", true)
-		}
-
 		if !rc.SkipNonConstraints {
 			if err := reflectExamples(rc, &propertySchema, field); err != nil {
 				return err


### PR DESCRIPTION
## Description
This is a part of fixing swaggest/openapi-go#145. Both of these members are [official parts of `jsonschema`](https://json-schema.org/draft/2020-12/json-schema-validation#name-deprecated), so I'd like to treat them as such.

## Changes
* Add a couple of round-trip tests for the new members
* Add `writeOnly` and `deprecated` as members of `Schema`
* Remove code that handled `deprecated` separately as a part of `ExtraProperties`
## Testing
Review. See that tests pass.