### PR TITLE
Revert "Fix enums placement"

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -1379,33 +1379,15 @@ func reflectEnum(schema *Schema, fieldTag reflect.StructTag, fieldVal interface{
 	enum.loadFromField(fieldTag, fieldVal)
 
 	if len(enum.items) > 0 {
-		target := searchDeepestSchema(schema)
-		target.Enum = enum.items
-
+		schema.Enum = enum.items
 		if len(enum.names) > 0 {
-			if target.ExtraProperties == nil {
-				target.ExtraProperties = make(map[string]interface{}, 1)
+			if schema.ExtraProperties == nil {
+				schema.ExtraProperties = make(map[string]interface{}, 1)
 			}
 
 			schema.ExtraProperties[XEnumNames] = enum.names
 		}
 	}
-}
-
-func searchDeepestSchema(in *Schema) *Schema {
-	if in.Items == nil {
-		return in
-	}
-
-	if in.Items.SchemaOrBool == nil {
-		return in
-	}
-
-	if in.Items.SchemaOrBool.TypeObject == nil {
-		return in
-	}
-
-	return searchDeepestSchema(in.Items.SchemaOrBool.TypeObject)
 }
 
 // enum can be use for sending enum data that need validate.

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -2655,34 +2655,3 @@ func TestReflector_Reflect_byteSlice(t *testing.T) {
 	  "type":"object"
 	}`, s)
 }
-
-func TestReflector_Reflect_EnumsPlacement(t *testing.T) {
-	r := jsonschema.Reflector{}
-
-	type Check struct {
-		A int                      `json:"a" enum:"1"`
-		B []string                 `json:"b" enum:"check-string"`
-		C []withValNamedEnum       `json:"c"`
-		D [][][]string             `json:"d" enum:"d"`
-		F map[string]string        `json:"f" enum:"f"`
-		G map[int]map[string][]int `json:"g" enum:"1"`
-	}
-
-	got, err := r.Reflect(Check{})
-	require.NoError(t, err)
-
-	assertjson.EqMarshal(t, `{
-	  "definitions": {
-		"JsonschemaGoTestWithValNamedEnum": {"enum": [""],"type": "string","x-enum-names": ["n:"]}
-	  },
-	  "properties":{
-		"a":{"enum":["1"],"type":"integer"},
-		"b":{"items":{"enum":["check-string"],"type":"string"},"type":["array","null"]},
-		"c":{"items":{"$ref":"#/definitions/JsonschemaGoTestWithValNamedEnum"},"type":["array","null"]},
-		"d":{"items":{"items":{"items":{"enum":["d"],"type":"string"},"type":"array"},"type":"array"},"type":["array","null"]},
-		"f":{"additionalProperties":{"type":"string"},"enum":["f"],"type":["object","null"]},
-		"g":{"additionalProperties":{"additionalProperties":{"items":{"type":"integer"},"type":"array"},"type":"object"},"enum":["1"],"type":["object","null"]}
-	  },
-	  "type":"object"
-	}`, got)
-}


### PR DESCRIPTION
Reverts swaggest/jsonschema-go#124

It turned out this implementation does not work well with actual types (e.g. you get `["1", "2", "3"]` for a enum of []int).