### PR TITLE
Fix double field bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ type MyObj struct {
 }
 ```
 
-Note: field tags are only applied to inline schemas, if you use named type then referenced schema
-will be created and tags will be ignored. This happens because referenced schema can be used in
-multiple fields with conflicting tags, therefore customization of referenced schema has to done on
-the type itself via `RawExposer`, `Exposer` or `Preparer`.
+Note: named types usually become referenced schemas. Field-local tags remain attached to the
+referencing field schema; when they need to coexist with a `$ref`, reflector wraps the reference in
+`allOf` to avoid draft-07 `$ref` sibling semantics. Customization of the referenced type itself can
+still be done on the type via `RawExposer`, `Exposer` or `Preparer`.
 
 Each tag value has to be put in double quotes (`"123"`).
 

--- a/reflect.go
+++ b/reflect.go
@@ -1218,9 +1218,20 @@ func (r *Reflector) walkProperties(v reflect.Value, parent *Schema, rc *ReflectC
 			reflectEnum(rc, &propertySchema, "", field.Tag, fieldVal)
 		}
 
-		// Remove temporary kept type from referenced schema.
+		// Remove temporary kept type from referenced schema and wrap local keywords
+		// around references to avoid draft-07 "$ref" sibling semantics.
 		if propertySchema.Ref != nil {
 			propertySchema.Type = nil
+
+			if hasRefSiblings(&propertySchema) {
+				refSchema := Schema{
+					Ref:         propertySchema.Ref,
+					ReflectType: propertySchema.ReflectType,
+				}
+
+				propertySchema.Ref = nil
+				propertySchema.AllOf = append([]SchemaOrBool{refSchema.ToSchemaOrBool()}, propertySchema.AllOf...)
+			}
 		}
 
 		if rc.interceptProp != nil {
@@ -1320,6 +1331,25 @@ func checkInlineValue(propertySchema *Schema, rc *ReflectContext, field reflect.
 	}
 
 	return nil
+}
+
+func hasRefSiblings(schema *Schema) bool {
+	if schema == nil || schema.Ref == nil {
+		return false
+	}
+
+	c := *schema
+	c.Ref = nil
+	c.Type = nil
+	c.ReflectType = nil
+	c.Parent = nil
+
+	j, err := json.Marshal(c)
+	if err != nil {
+		return true
+	}
+
+	return string(j) != "{}"
 }
 
 // checkNullability checks Go semantic conditions and adds null type to schemas when appropriate.

--- a/reflect.go
+++ b/reflect.go
@@ -1193,13 +1193,13 @@ func (r *Reflector) walkProperties(v reflect.Value, parent *Schema, rc *ReflectC
 		checkNullability(&propertySchema, rc, ft, omitEmpty, nullable)
 
 		if !rc.SkipNonConstraints {
-			err = checkInlineValue(&propertySchema, field, "default", propertySchema.WithDefault)
+			err = checkInlineValue(&propertySchema, rc, field, "default", propertySchema.WithDefault)
 			if err != nil {
 				return fmt.Errorf("%s: %w", strings.Join(append(rc.Path[1:], field.Name), "."), err)
 			}
 		}
 
-		err = checkInlineValue(&propertySchema, field, "const", propertySchema.WithConst)
+		err = checkInlineValue(&propertySchema, rc, field, "const", propertySchema.WithConst)
 		if err != nil {
 			return err
 		}
@@ -1253,7 +1253,7 @@ func (r *Reflector) walkProperties(v reflect.Value, parent *Schema, rc *ReflectC
 	return nil
 }
 
-func checkInlineValue(propertySchema *Schema, field reflect.StructField, tag string, setter func(interface{}) *Schema) error {
+func checkInlineValue(propertySchema *Schema, rc *ReflectContext, field reflect.StructField, tag string, setter func(interface{}) *Schema) error {
 	var (
 		val interface{}
 		t   SimpleType
@@ -1264,8 +1264,13 @@ func checkInlineValue(propertySchema *Schema, field reflect.StructField, tag str
 		b *bool
 	)
 
-	if propertySchema.Type != nil && propertySchema.Type.SimpleTypes != nil {
-		t = *propertySchema.Type.SimpleTypes
+	valueSchema := propertySchema
+	if valueSchema.Ref != nil && valueSchema.Type == nil {
+		valueSchema = rc.getDefinition(*valueSchema.Ref)
+	}
+
+	if valueSchema.Type != nil && valueSchema.Type.SimpleTypes != nil {
+		t = *valueSchema.Type.SimpleTypes
 	}
 
 	_ = refl.ReadIntPtrTag(field.Tag, tag, &i)   //nolint:errcheck
@@ -1274,13 +1279,13 @@ func checkInlineValue(propertySchema *Schema, field reflect.StructField, tag str
 	refl.ReadStringPtrTag(field.Tag, tag, &s)
 
 	switch {
-	case propertySchema.HasType(Number) && f != nil:
+	case valueSchema.HasType(Number) && f != nil:
 		val = *f
-	case propertySchema.HasType(Integer) && i != nil:
+	case valueSchema.HasType(Integer) && i != nil:
 		val = *i
-	case propertySchema.HasType(Boolean) && b != nil:
+	case valueSchema.HasType(Boolean) && b != nil:
 		val = *b
-	case propertySchema.HasType(String) && s != nil:
+	case valueSchema.HasType(String) && s != nil:
 		val = *s
 	case t == Null:
 		// No default for type null.
@@ -1299,9 +1304,9 @@ func checkInlineValue(propertySchema *Schema, field reflect.StructField, tag str
 		}
 
 		if strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]") &&
-			propertySchema.Items != nil &&
-			propertySchema.Items.SchemaOrBool != nil &&
-			propertySchema.Items.SchemaOrBool.TypeObject.HasType(String) {
+			valueSchema.Items != nil &&
+			valueSchema.Items.SchemaOrBool != nil &&
+			valueSchema.Items.SchemaOrBool.TypeObject.HasType(String) {
 			val = strings.Split(v[1:len(v)-1], ",")
 
 			break
@@ -1413,7 +1418,7 @@ func reflectExamples(rc *ReflectContext, propertySchema *Schema, field reflect.S
 }
 
 func reflectExample(rc *ReflectContext, propertySchema *Schema, field reflect.StructField) error {
-	err := checkInlineValue(propertySchema, field, "example", func(i interface{}) *Schema {
+	err := checkInlineValue(propertySchema, rc, field, "example", func(i interface{}) *Schema {
 		return propertySchema.WithExamples(i)
 	})
 	if err != nil {

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -722,7 +722,8 @@ func TestReflector_Reflect_inclineScalar(t *testing.T) {
 	type Symbol string
 
 	type topTracesInput struct {
-		RootSymbol Symbol `json:"rootSymbol" minLength:"5" example:"my_func" default:"main()"`
+		RootSymbol  Symbol `json:"rootSymbol" minLength:"5" example:"my_func" default:"main()"`
+		RootSymbol2 Symbol `json:"rootSymbol2" minLength:"5" example:"my_second_func" default:"main()"`
 	}
 
 	r := jsonschema.Reflector{}
@@ -730,7 +731,8 @@ func TestReflector_Reflect_inclineScalar(t *testing.T) {
 	require.NoError(t, err)
 	assertjson.EqualMarshal(t, []byte(`{
 	  "properties":{
-		"rootSymbol":{"default":"main()","examples":["my_func"],"minLength":5,"type":"string"}
+		"rootSymbol":{"default":"main()","examples":["my_func"],"minLength":5,"type":"string"},
+		"rootSymbol2":{"default":"main()","examples":["my_second_func"],"minLength":5,"type":"string"}
 	  },
 	  "type":"object"
 	}`), s)
@@ -2079,7 +2081,8 @@ func (d *Discover) Enum() []interface{} {
 
 func TestReflector_Reflect_ptrDefault(t *testing.T) {
 	type NewThing struct {
-		DiscoverMode *Discover `json:"discover,omitempty" default:"all"`
+		DiscoverMode  *Discover `json:"discover,omitempty" default:"all"`
+		DiscoverMode2 *Discover `json:"discover2,omitempty" default:"all"`
 	}
 
 	r := jsonschema.Reflector{}
@@ -2091,7 +2094,8 @@ func TestReflector_Reflect_ptrDefault(t *testing.T) {
 		"JsonschemaGoTestDiscover":{"enum":["all","none"],"type":["null","string"]}
 	  },
 	  "properties":{
-		"discover":{"$ref":"#/definitions/JsonschemaGoTestDiscover","default":"all"}
+		"discover":{"$ref":"#/definitions/JsonschemaGoTestDiscover","default":"all"},
+		"discover2":{"$ref":"#/definitions/JsonschemaGoTestDiscover","default":"all"}
 	  },
 	  "type":"object"
 	}`, s)

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -449,7 +449,10 @@ func TestReflector_Reflect_pointer_envelop(t *testing.T) {
 		  "minProperties":5,
 		  "anyOf":[{"type":"null"},{"$ref":"#/definitions/JsonschemaGoTestNamedMap"}]
 		},
-		"namedMapOmitempty":{"$ref":"#/definitions/JsonschemaGoTestNamedMap","minProperties":1},
+		"namedMapOmitempty":{
+		  "allOf":[{"$ref":"#/definitions/JsonschemaGoTestNamedMap"}],
+		  "minProperties":1
+		},
 		"ptr":{"anyOf":[{"type":"null"},{"$ref":"#/definitions/JsonschemaGoTestSt"}]},
 		"ptrOmitempty":{"$ref":"#/definitions/JsonschemaGoTestSt"},
 		"slice":{
@@ -507,8 +510,14 @@ func TestReflector_Reflect_pointer(t *testing.T) {
 		  "additionalProperties":{"$ref":"#/definitions/JsonschemaGoTestSt"},
 		  "type":"object"
 		},
-		"namedMap":{"$ref":"#/definitions/JsonschemaGoTestNamedMap","minProperties":5},
-		"namedMapOmitempty":{"$ref":"#/definitions/JsonschemaGoTestNamedMap","minProperties":1},
+		"namedMap":{
+		  "allOf":[{"$ref":"#/definitions/JsonschemaGoTestNamedMap"}],
+		  "minProperties":5
+		},
+		"namedMapOmitempty":{
+		  "allOf":[{"$ref":"#/definitions/JsonschemaGoTestNamedMap"}],
+		  "minProperties":1
+		},
 		"ptr":{"$ref":"#/definitions/JsonschemaGoTestSt"},
 		"ptrOmitempty":{"$ref":"#/definitions/JsonschemaGoTestSt"},
 		"slice":{
@@ -605,8 +614,14 @@ func TestExposer(t *testing.T) {
 		}
 	  },
 	  "properties":{
-		"country":{"$ref":"#/definitions/JsonschemaGoTestISOCountry","deprecated":true},
-		"ptr_country":{"$ref":"#/definitions/JsonschemaGoTestISOCountry","deprecated":true},
+		"country":{
+		  "allOf":[{"$ref":"#/definitions/JsonschemaGoTestISOCountry"}],
+		  "deprecated":true
+		},
+		"ptr_country":{
+		  "allOf":[{"$ref":"#/definitions/JsonschemaGoTestISOCountry"}],
+		  "deprecated":true
+		},
 		"ptr_exp":{"examples":["bar"],"type":"string"},
 		"ptr_raw":{"examples":["foo"],"type":["string","null"]},
 		"ptr_week":{"$ref":"#/definitions/JsonschemaGoTestISOWeek"},
@@ -1300,7 +1315,7 @@ func TestReflector_Reflect_namedSlice(t *testing.T) {
 	  },
 	  "properties":{
 		"ip_policy":{
-		  "$ref":"#/definitions/JsonschemaGoTestPanicType",
+		  "allOf":[{"$ref":"#/definitions/JsonschemaGoTestPanicType"}],
 		  "examples":[["127.0.0.1"]]
 		}
 	  },
@@ -2082,7 +2097,7 @@ func (d *Discover) Enum() []interface{} {
 func TestReflector_Reflect_ptrDefault(t *testing.T) {
 	type NewThing struct {
 		DiscoverMode  *Discover `json:"discover,omitempty" default:"all"`
-		DiscoverMode2 *Discover `json:"discover2,omitempty" default:"all"`
+		DiscoverMode2 *Discover `json:"discover2,omitempty" default:"none"`
 	}
 
 	r := jsonschema.Reflector{}
@@ -2094,8 +2109,14 @@ func TestReflector_Reflect_ptrDefault(t *testing.T) {
 		"JsonschemaGoTestDiscover":{"enum":["all","none"],"type":["null","string"]}
 	  },
 	  "properties":{
-		"discover":{"$ref":"#/definitions/JsonschemaGoTestDiscover","default":"all"},
-		"discover2":{"$ref":"#/definitions/JsonschemaGoTestDiscover","default":"all"}
+		"discover":{
+		  "allOf":[{"$ref":"#/definitions/JsonschemaGoTestDiscover"}],
+		  "default":"all"
+		},
+		"discover2":{
+		  "allOf":[{"$ref":"#/definitions/JsonschemaGoTestDiscover"}],
+		  "default":"none"
+		}
 	  },
 	  "type":"object"
 	}`, s)


### PR DESCRIPTION
This is a reformulation of #113. I've added additional code to support the suggestion from the other PR. I wanted to change the branch off of master in my own fork.

Test changes: 
 - I've changed the test `TestReflector_Reflect_ptrDefault`, which currently breaks on `master` when the second field is included (you do not get json schema, because specifying the default twice on a named type breaks the package).
 - I've updated other tests that broke when removing siblings from `$ref`. Hopefully this is desirable!

jsonschema-go has a subtle bug: when resolving complex types, second or more redeclarations of the same type would cause some parsing to fall back to json parsing.

The first commit fixes an issue where the reflect did not have enough information to parse tags like default or example on second or more definitions. On later occurrences, it reused an existing $ref and lost that local type metadata, so parsing fell back to generic JSON decoding. 

For string-like values, that caused errors such as all being rejected because valid JSON would need `"all"` (not `all`).

The second commit fixes the [`allOf` issue](https://github.com/swaggest/jsonschema-go/pull/113#issuecomment-1991177595) that the PR review comment alludes to: instead of placing siblings to `ref`, we optionally wrap the reference in an `allOf` which we can then safely specify other properties for.